### PR TITLE
Adding AdSupport framework dependency to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -238,6 +238,7 @@
 
     <!-- ios -->
     <platform name="ios">
+      <framework src="AdSupport.framework" />
       <config-file target="config.xml" parent="/*">
         <feature name="PushNotification">
           <param name="ios-package" value="PushNotification"/>


### PR DESCRIPTION
iOS build fails without linking the AdSupport framework.

Dependency was created by commit 36d01833142a09abd21c2fc788b0617df51f6397 in [PushNotificationManager.m](https://github.com/shaders/pushwoosh-phonegap-3.0-plugin/blob/36d01833142a09abd21c2fc788b0617df51f6397/src/ios/PushNotificationManager.m#L29)
