### PR TITLE
Storekit.framework import was missing

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -123,6 +123,7 @@
     <!-- ios -->
     <platform name="ios">
       <framework src="Security.framework" />
+      <framework src="Storekit.framework" />
       <config-file target="config.xml" parent="/*">
         <feature name="PushNotification">
           <param name="ios-package" value="PushNotification"/>


### PR DESCRIPTION
Hi, since the last update of the iOS version of the plugin a dependency was added for Storekit.framework, but the dependency was not added to plugin.xml (leading to compiler errors while building for iOS).
