### PR TITLE
Change execScript to eval as execScript not supported on wp8.1

### DIFF
--- a/src/wp8/PushNotification.cs
+++ b/src/wp8/PushNotification.cs
@@ -221,7 +221,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                         try
                         {
                             string pushPayload = JsonConvert.SerializeObject(push);
-                            cView.Browser.InvokeScript("execScript", "cordova.require(\"com.pushwoosh.plugins.pushwoosh.PushNotification\").notificationCallback(" + pushPayload + ")");
+                            cView.Browser.InvokeScript("eval", "cordova.require(\"com.pushwoosh.plugins.pushwoosh.PushNotification\").notificationCallback(" + pushPayload + ")");
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
According to https://github.com/phonegap-build/PushPlugin/issues/397 and tested by me and our team, execScript raises an exception with the app opened. Changing it to 'eval' corrects the issue, and 'eval' is also supported on wp8.