### PR TITLE
replace .jar with <framework>

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -135,14 +135,8 @@
 							target-dir="src/com/pushwoosh/plugin/pushnotifications" />
 
 			<source-file src="src/android/lib/Pushwoosh.jar" target-dir="libs" />
-<<<<<<< HEAD
 			<source-file src="src/android/lib/google-play-services.jar" target-dir="libs" />
-			<source-file src="src/android/lib/android-support-v4.jar" target-dir="libs" />
-=======
-			<framework src="com.google.android.gms:play-services-gcm:+" />
-			<framework src="com.google.android.gms:play-services-location:+" />
 			<framework src="com.android.support:support-v4:+" />
->>>>>>> master
 		</platform>
 
 		<!-- ios -->


### PR DESCRIPTION
replace the `android-support-v4.jar` with `<framework src="com.android.support:support-v4:+" />`, cause if another plugin has `<framework src="com.android.support:support-v4:+" />`, then intel-xdk build was failing.

`google-play-services.jar` also cause build failure in IntelXDK if another plugin has `<framework src="com.google.android.gms:play-services-gcm:+" />`, but this cannot be replaced because of gradle workaround.

also a merge conflict was not fixed in last commit for intel-xdk branch.

