### PR TITLE
Fix issue 149 with [INSTALL_FAILED_CONFLICTING_PROVIDER]

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,7 +84,7 @@
 
 			<config-file target="AndroidManifest.xml" parent="/manifest/application">
 				<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
-				
+
 				<!-- Push notification services -->
 				<activity android:name="com.pushwoosh.MessageActivity" />
 				<activity android:name="com.pushwoosh.PushHandlerActivity" />
@@ -137,6 +137,7 @@
 			<source-file src="src/android/lib/Pushwoosh.jar" target-dir="libs" />
 			<framework src="com.google.android.gms:play-services-gcm:+" />
 			<framework src="com.google.android.gms:play-services-location:+" />
+      <framework src="push.gradle" custom="true" type="gradleReference" />
 			<framework src="com.android.support:support-v4:+" />
 		</platform>
 

--- a/push.gradle
+++ b/push.gradle
@@ -1,0 +1,21 @@
+import java.util.regex.Pattern
+
+def doExtractStringFromManifest(name) {
+    def manifestFile = file(android.sourceSets.main.manifest.srcFile)
+    def pattern = Pattern.compile(name + "=\"(.*?)\"")
+    def matcher = pattern.matcher(manifestFile.getText())
+    matcher.find()
+    return matcher.group(1)
+}
+
+android {
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+        }
+    }
+
+    defaultConfig {
+        applicationId = doExtractStringFromManifest("package")
+    }
+}


### PR DESCRIPTION
So, the proposed fix in https://github.com/Pushwoosh/pushwoosh-phonegap-plugin/issues/149 is not really the right way of fixing this. Writing stuff in the `gradle.build` gets overwritten later because the file is generated.

I came across this issue and made a post in the Google Groups for Phonegap ( https://groups.google.com/forum/#!topic/phonegap/bIef9FU1RJY ) and got pointed to a fixed issue in the PluginPush ( https://github.com/phonegap/phonegap-plugin-push/commit/15b76632ac2849f1cb2f48e75a5292dfaa97de7f )

This PR does the same fix here, so people don't have to edit unedited files.

Also, this would make your documentation better by removing this warning:
<img width="765" alt="screen shot 2016-02-08 at 16 02 33" src="https://cloud.githubusercontent.com/assets/459764/12889043/6288ab72-ce7d-11e5-9624-53e21b8fdeb8.png">
