### PR TITLE
Experimental React Native Android Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,33 @@ http://www.pushwoosh.com/programming-push-notification/windows-phone/wp-addition
 ###Plugin documentation:  
 https://rawgit.com/Pushwoosh/pushwoosh-phonegap-3.0-plugin/master/Documentation/files/PushNotification-js.html
 
+###Experimental Support For React Native Android:
+By using the [react-native-cordova-plugin](https://github.com/axemclion/react-native-cordova-plugin) package, Cordova plugins can be used with React Native applications (only Android right now).
+
+To add this plugin to a React Native Android project:
+- Run `npm install --save react-native-cordova-plugin`
+- Follow the instructions to finish the installation in the [package docs](https://github.com/axemclion/react-native-cordova-plugin)
+- Run `./node_modules/.bin/cordova-plugin add https://github.com/UpChannel/pushwoosh-phonegap-plugin`
+
+Then in your JS you can use the API similarly, with three key differences:
+```javascript
+// need to require Cordova:
+var Cordova = require('react-native-cordova-plugin');
+...
+// need to require PushNotification plugin as such:
+var pushNotification = Cordova.require("pushwoosh-cordova-plugin.PushNotification");
+...
+// Need to set a callback for incoming push notifications instead of an event listener:
+pushNotification.setNotificationCallback(function(event){
+	...
+});
+// DO NOT USE FOLLOWING IN REACT NATIVE (WILL ERROR)
+document.addEventListener('push-notification', function(event) {
+	...
+});
+```
+These differences are due to the different Javascript execution environment in React Native. Since there is no window or document object, we cannot use either of those APIs.
+
 ## Acknowledgments
 Plugman support by Platogo
 
@@ -29,20 +56,20 @@ https://github.com/EddyVerbruggen
 ## LICENSE
 
 	The MIT License
-	
+
 	Copyright (c) 2014 Pushwoosh.
 	http://www.pushwoosh.com
-	
+
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
 	in the Software without restriction, including without limitation the rights
 	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 	copies of the Software, and to permit persons to whom the Software is
 	furnished to do so, subject to the following conditions:
-	
+
 	The above copyright notice and this permission notice shall be included in
 	all copies or substantial portions of the Software.
-	
+
 	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="pushwoosh-cordova-plugin" version="5.0.1">
-	
+
 	<name>Pushwoosh</name>
 
 	<description>
@@ -51,9 +51,9 @@
 			 where PACKAGE is the application's package name.
 			 -->
 			<permission
-				android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"
+				android:name="${applicationId}.permission.C2D_MESSAGE"
 				android:protectionLevel="signature"/>
-			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
+			<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE"/>
 
 			<!-- This app has permission to register and receive data message. -->
 			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -51,9 +51,9 @@
 			 where PACKAGE is the application's package name.
 			 -->
 			<permission
-				android:name="${applicationId}.permission.C2D_MESSAGE"
+				android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"
 				android:protectionLevel="signature"/>
-			<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE"/>
+			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
 
 			<!-- This app has permission to register and receive data message. -->
 			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>

--- a/spec/pushwoosh.tests.js
+++ b/spec/pushwoosh.tests.js
@@ -148,4 +148,9 @@ describe('cordova.require object should exist', function () {
         expect(typeof PushNotification.notificationCallback == 'function').toBe(true);
     });
 
+    it("should contain an setNotificationCallback function", function() {
+        expect(PushNotification.setNotificationCallback).toBeDefined();
+        expect(typeof PushNotification.setNotificationCallback == 'function').toBe(true);
+    });
+
 });

--- a/www/PushNotification.js
+++ b/www/PushNotification.js
@@ -20,8 +20,11 @@ var exec = require('cordova/exec');
 //				pushwoosh.onDeviceReady({ projectid: "XXXXXXXXXXXXXXX", pw_appid : "XXXXX-XXXXX" });
 //(end)
 function PushNotification() {
-	this.customNotificationCallback = null;
 }
+
+// Used to keep track of the set callback for an incoming push notification.
+// Not set as a property of PushNotification in order to preserve usage instructions for this plugin.
+var customNotificationCallback = null;
 
 //Function: registerDevice
 //Call this to register for push notifications and retreive a push Token
@@ -365,8 +368,8 @@ PushNotification.prototype.notificationCallback = function(notification) {
 		document.dispatchEvent(ev);
 	}
 	// call the custom callback if one has been supplied
-	if (typeof this.customNotificationCallback === 'function') {
-		this.customNotificationCallback(notification);
+	if (typeof customNotificationCallback === 'function') {
+		customNotificationCallback(notification);
 	}
 };
 
@@ -375,7 +378,7 @@ PushNotification.prototype.notificationCallback = function(notification) {
 //Useful as an alternative to using browser-based events.
 PushNotification.prototype.setNotificationCallback = function(callback) {
 	if (typeof callback === 'function') {
-		this.customNotificationCallback = callback;
+		customNotificationCallback = callback;
 	}
 }
 

--- a/www/PushNotification.js
+++ b/www/PushNotification.js
@@ -19,7 +19,9 @@ var exec = require('cordova/exec');
 //	    	    var pushwoosh = cordova.require("pushwoosh-cordova-plugin.PushNotification");
 //				pushwoosh.onDeviceReady({ projectid: "XXXXXXXXXXXXXXX", pw_appid : "XXXXX-XXXXX" });
 //(end)
-function PushNotification() {}
+function PushNotification() {
+	this.customNotificationCallback = null;
+}
 
 //Function: registerDevice
 //Call this to register for push notifications and retreive a push Token
@@ -355,10 +357,26 @@ PushNotification.prototype.postEvent = function(event, attributes) {
 
 // Event spawned when a notification is received while the application is active
 PushNotification.prototype.notificationCallback = function(notification) {
-	var ev = document.createEvent('HTMLEvents');
-	ev.notification = notification;
-	ev.initEvent('push-notification', true, true, arguments);
-	document.dispatchEvent(ev);
+	// check if document is available before using it
+	if (typeof document === 'object') {
+		var ev = document.createEvent('HTMLEvents');
+		ev.notification = notification;
+		ev.initEvent('push-notification', true, true, arguments);
+		document.dispatchEvent(ev);
+	}
+	// call the custom callback if one has been supplied
+	if (typeof this.customNotificationCallback === 'function') {
+		this.customNotificationCallback(notification);
+	}
 };
+
+//Function: setNotificationCallback
+//Call this with a callback function that will be called when a push notification is received.
+//Useful as an alternative to using browser-based events.
+PushNotification.prototype.setNotificationCallback = function(callback) {
+	if (typeof callback === 'function') {
+		this.customNotificationCallback = callback;
+	}
+}
 
 module.exports = new PushNotification();


### PR DESCRIPTION
Only small changes needed to be made to this plugin to support React Native on Android.

The major change is that references to `window` and `document` are not available, so events are not possible. This fork checks for existence of document before using events, and allows custom callbacks to be set to receive push notifications in JS. 

The usage instructions have to be modified a bit because there is no global window object, and therefore no global cordova object in React Native. Those changes are reflected in the new section in the Readme.