### PR TITLE
Fix missing Push Notifications capability in Xcode 8

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -139,13 +139,12 @@
 			<string>$IOS_FOREGROUND_ALERT_TYPE</string>
 		</config-file>
 
-        	<config-file target="Entitlements-Debug.plist" parent="aps-environment">
-            		<string>development</string>
-        	</config-file>
-
-        	<config-file target="Entitlements-Release.plist" parent="aps-environment">
-            		<string>production</string>
-        	</config-file>
+		<config-file parent="aps-environment" target="*/Entitlements-Debug.plist">
+			<string>development</string>
+		</config-file>
+		<config-file parent="aps-environment" target="*/Entitlements-Release.plist">
+			<string>production</string>
+		</config-file>
 
 		<header-file src="src/ios/PushNotification.h" target-dir="ios"/>
 		<source-file src="src/ios/PushNotification.m" target-dir="ios"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -139,6 +139,14 @@
 			<string>$IOS_FOREGROUND_ALERT_TYPE</string>
 		</config-file>
 
+        	<config-file target="Entitlements-Debug.plist" parent="aps-environment">
+            		<string>development</string>
+        	</config-file>
+
+        	<config-file target="Entitlements-Release.plist" parent="aps-environment">
+            		<string>production</string>
+        	</config-file>
+
 		<header-file src="src/ios/PushNotification.h" target-dir="ios"/>
 		<source-file src="src/ios/PushNotification.m" target-dir="ios"/>
 		<header-file src="src/ios/Pushwoosh.framework/Versions/A/Headers/PushNotificationManager.h" target-dir="ios"/>


### PR DESCRIPTION
With the new Xcode 8 changes, you have to enable Push Notifications as a Capability in the Capabilities tab. This PR will automatically add this capability when `cordova-ios@4.3.0` is released.
