### PR TITLE
Fixed javascript execution security flaw with android push notifications

### DIFF
--- a/src/android/src/com/pushwoosh/plugin/pushnotifications/PushNotifications.java
+++ b/src/android/src/com/pushwoosh/plugin/pushnotifications/PushNotifications.java
@@ -901,7 +901,7 @@ public class PushNotifications extends CordovaPlugin
 		String result = unifiedNotification.toString();
 
 		// wrap special characters
-		result.replace("%", "%\"+\"");
+		result = result.replace("%", "%\"+\"");
 
 		return result;
 	}


### PR DESCRIPTION
This should also fix bugs with the google.message_id either being wrong, or
triggering an "Uncaught SyntaxError: Unexpected token ILLEGAL" error
(e.g. with a message_id containing "%0a"). The latter issue stops all
push notifications from working.

This occurs as % were not escaped correctly (String.replace doesn't
alter the original string). This allows any character to be escaped
using the appropriate percentage escape code, allowing any javascript to
be executed. This is a major issue with push notifications that contain
user supplied input (e.g a chat message reply).

This was previously raised in #197 (but the security issues weren't
noted). It was fixed by commit a4361858e45d07a9171a232d5bc58636179e018d,
however was broken again in commit c809240b46141102641047cc38fc06791d6b8357.

It is probably worthwhile removing the evalJs function entirely, and
replacing with a more secure method for triggering js events from push
notifications coming in. It is hard to prove there aren't other
issues with this code considering there is two levels of escaping
going on (url and json).