### PR TITLE
Support for Android X Libraries.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,17 +58,17 @@
 		<framework src="com.google.firebase:firebase-core:(+,17.0.0)" />
 		<framework src="com.google.firebase:firebase-messaging:(+,19.0.0)" />
 
-		<framework src="com.android.support:support-v4:27.+" />
-        <framework src="com.android.support:appcompat-v7:27.+" />
-        <framework src="com.android.support:recyclerview-v7:27.+" />
-        <framework src="com.android.support:design:27.+" />
-        <framework src="com.android.support.constraint:constraint-layout:1.0.2" />
-        <framework src="com.github.bumptech.glide:glide:4.7.1" />
-        <framework src="org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.60" />
+        <framework src="androidx.legacy:legacy-support-v4:1.0.0"/>
+        <framework src="androidx.appcompat:appcompat:1.0.0"/>
+        <framework src="androidx.recyclerview:recyclerview:1.0.0"/>
+        <framework src="com.google.android.material:material:1.0.0"/>
+        <framework src="androidx.constraintlayout:constraintlayout:1.1.3"/>
+        <framework src="com.github.bumptech.glide:glide:4.7.1"/>
+        <framework src="org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.60"/>
         <framework src="com.pushwoosh:pushwoosh:6.0.5"/>
-		<framework src="com.pushwoosh:pushwoosh-amazon:6.0.5"/>
+        <framework src="com.pushwoosh:pushwoosh-amazon:6.0.5"/>
         <framework src="com.pushwoosh:pushwoosh-firebase:6.0.5"/>
-		<framework src="com.pushwoosh:pushwoosh-badge:6.0.5"/>
+        <framework src="com.pushwoosh:pushwoosh-badge:6.0.5"/>
         <framework src="com.pushwoosh:pushwoosh-inbox:6.0.5"/>
         <framework src="com.pushwoosh:pushwoosh-inbox-ui:6.0.5"/>
 	</platform>


### PR DESCRIPTION
For the upcomming support for Android X you can use the new Android X naming.
I changed the naming of the suport libraries and that effacts to get the new support legacy libraries under a new namespace.

