### PR TITLE
Remove platform version code because of issue in mabs7

### DIFF
--- a/hooks/outsystems/utils.js
+++ b/hooks/outsystems/utils.js
@@ -6,15 +6,8 @@ var fs = require("fs");
  * @returns {string} platform version
  */
 function getPlatformVersion(context) {
-    var projectRoot = context.opts.projectRoot;
-    var platformsJsonFile = path.join(
-        projectRoot,
-        "platforms",
-        "platforms.json"
-    );
-    var platforms = require(platformsJsonFile);
-    var platform = context.opts.plugin.platform;
-    return platforms[platform];
+    var platform = context.opts.cordova.version;
+    return platform;
 }
 
 function rmNonEmptyDir(dir_path) {


### PR DESCRIPTION
Removed old unused code retrieving platform version because of issue in mabs7

[See similar fix](https://github.com/os-adv-dev/cordova-plugin-facebook4/commit/25b95faf4764b3b641c19a0ccbe2ce8eeb0ae09c)