### PR TITLE
Update dependency to cordova-androidx-build to support Mabs 7.0+

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,7 @@
 			target-dir="src/com/pushwoosh/plugin/internal" />
 
 		<framework src="libs/android/googleservices-build.gradle" custom="true" type="gradleReference" />
-		<dependency id="cordova-androidx-build" url="https://github.com/Pushwoosh/cordova-androidx-build.git#1.1-OS" />
+		<dependency id="cordova-androidx-build" url="https://github.com/Pushwoosh/cordova-androidx-build.git" />
 	</platform>
 
 	<!-- ios -->


### PR DESCRIPTION
Version from https://github.com/Pushwoosh/cordova-androidx-build.git#1.1-OS" is not compatible with MABS 7.0 so we are changing to look to master since it already has replaced the usage of requireCordovaModule